### PR TITLE
Add failing test for curses hline and vline support

### DIFF
--- a/tests/fixtures/box.py
+++ b/tests/fixtures/box.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import curses
+
+
+def start(screen):
+    curses.cbreak()
+    curses.noecho()
+    curses.curs_set(0)
+
+    text_window = screen.subwin(3, 12, 0, 0)
+    text_window.box()
+    text_window.addstr(1, 1, "I am a box")
+    screen.noutrefresh()
+    text_window.noutrefresh()
+    curses.doupdate()
+
+    while True:
+        c = screen.getch()
+        if c == ord('q'):
+            break
+
+    curses.endwin()
+
+
+def main():
+    curses.wrapper(start)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hecate.py
+++ b/tests/test_hecate.py
@@ -8,7 +8,6 @@ import sys
 import os
 import signal
 
-
 Runner.print_on_exit = True
 
 
@@ -115,3 +114,12 @@ def test_uses_last_screenshot_if_server_goes_away():
         controller = h.report_variables()[r.CONTROLLER]
         os.kill(controller, signal.SIGKILL)
         assert "Hello" in h.screenshot()
+
+
+def test_can_capture_curses_hline_and_vline_characters():
+    with Runner("./tests/fixtures/box.py") as h:
+        h.await_text("┌──────────┐")
+        h.await_text("│I am a box│")
+        h.await_text("└──────────┘")
+        h.press("q")
+        h.await_exit()


### PR DESCRIPTION
_This pull request is meant to be the starting point for a discussion and is not intended as a candidate for acceptance as-is._

I'd love to write integration tests for `curses` applications using `hecate`.  To get started, I wrote a trivial `curses` application, `box.py`.  When `box.py` is run, the screen should have this box in the upper left hand corner (and typing `q` should cause `box.py` to exit):

```
┌──────────┐
│I am a box│
└──────────┘
```

I wrote a `hecate` test that asserts what the screen should look when `box.py` runs.

The current out-of-the-box configuration results in a captured screen that looks like this when run through the `Runner` class:

```
lqqqqqqqqqqk
xI am a boxx
mqqqqqqqqqqj
```

I'd be quite interested in digging in and creating another commit as part of this pull request that implements the feature, but because I'm so unfamiliar with the core problem domain, I thought I would first propose the feature request in the form of a failing test and ask for the author's guidance, if any.
