### PR TITLE
Fix tests for tmux-2.6

### DIFF
--- a/src/hecate/tmux.py
+++ b/src/hecate/tmux.py
@@ -45,8 +45,10 @@ class Tmux(object):
                 stderr=subprocess.STDOUT
             ).decode()
         except subprocess.CalledProcessError as e:
-            if b"failed to connect to server: Connection refused" in e.output:
-                raise DeadServer(e.output)
+            if b"failed to connect to server: Connection refused" in e.output\
+               or b"no server running" in e.output:
+                raise DeadServer(e.output) from e
+
             raise CommandFailed(e.output)
 
     def new_session(

--- a/src/hecate/tmux.py
+++ b/src/hecate/tmux.py
@@ -43,7 +43,7 @@ class Tmux(object):
             return subprocess.check_output(
                 cmd,
                 stderr=subprocess.STDOUT
-            ).decode('ascii')
+            ).decode()
         except subprocess.CalledProcessError as e:
             if b"failed to connect to server: Connection refused" in e.output:
                 raise DeadServer(e.output)

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -61,8 +61,9 @@ def test_creates_sessions_of_desired_name():
 def test_can_capture_a_pane():
     name = "testcapturing"
     mux = newmux()
+    height = 50
     mux.new_session(
-        width=50, height=50, command="echo hello world; bash", name=name
+        width=50, height=height, command="echo hello world; bash", name=name
     )
     sessions = mux.sessions()
     assert name in sessions
@@ -74,7 +75,7 @@ def test_can_capture_a_pane():
     assert len(panes) == 1
     pane_contents = mux.capture_pane(panes[0])
     assert "hello world" in pane_contents
-    assert len(pane_contents.split("\n")) == 50
+    assert len(pane_contents.split("\n")) == height + 1
 
 
 def test_can_send_content_to_the_screen():


### PR DESCRIPTION
This pull request just fixes some failing tests:

```
$ pytest
============================= test session starts ==============================
platform linux -- Python 3.6.5, pytest-3.6.2, py-1.5.4, pluggy-0.6.0 -- /home/msirabella/Documents/projects/featurefork/neomutt/test/system/venv/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/msirabella/Documents/projects/featurefork/neomutt/test/system/hecate, inifile: tox.ini
collecting ... collected 19 items

tests/test_hecate.py::test_can_launch_a_simple_program PASSED            [  5%]
tests/test_hecate.py::test_can_kill_vim PASSED                           [ 10%]
tests/test_hecate.py::test_can_write_unicode FAILED                      [ 15%]
tests/test_hecate.py::test_can_run_vim PASSED                            [ 21%]
tests/test_hecate.py::test_can_send_enter PASSED                         [ 26%]
tests/test_hecate.py::test_reports_abnormal_exit PASSED                  [ 31%]
tests/test_hecate.py::test_can_send_eof PASSED                           [ 36%]
tests/test_hecate.py::test_sets_the_console_size_appropriately PASSED    [ 42%]
tests/test_hecate.py::test_can_send_signals_to_child PASSED              [ 47%]
tests/test_hecate.py::test_uses_last_screenshot_if_server_goes_away FAILED [ 52%]
tests/test_mux.py::test_muxes_are_independent PASSED                     [ 57%]
tests/test_mux.py::test_has_no_buffers_to_start_with PASSED              [ 63%]
tests/test_mux.py::test_can_save_data_to_a_buffer PASSED                 [ 68%]
tests/test_mux.py::test_can_set_data_to_an_existing_buffer PASSED        [ 73%]
tests/test_mux.py::test_starts_with_a_single_session PASSED              [ 78%]
tests/test_mux.py::test_creates_sessions_of_desired_name PASSED          [ 84%]
tests/test_mux.py::test_can_capture_a_pane FAILED                        [ 89%]
tests/test_mux.py::test_can_send_content_to_the_screen PASSED            [ 94%]
tests/test_mux.py::test_can_detect_when_server_dies FAILED               [100%]

=================================== FAILURES ===================================
____________________________ test_can_write_unicode ____________________________
tests/test_hecate.py:34: in test_can_write_unicode
    h.await_text("☃")
../venv/lib/python3.6/site-packages/hecate/hecate.py:224: in await_text
    screen = self.screenshot()
../venv/lib/python3.6/site-packages/hecate/hecate.py:194: in screenshot
    result = self.tmux.capture_pane(0)
../venv/lib/python3.6/site-packages/hecate/tmux.py:124: in capture_pane
    buf = self.a_buffer()
../venv/lib/python3.6/site-packages/hecate/tmux.py:115: in a_buffer
    buffers = self.buffers()
../venv/lib/python3.6/site-packages/hecate/tmux.py:70: in buffers
    return _extract_names(self.execute_command("list-buffers"))
../venv/lib/python3.6/site-packages/hecate/tmux.py:46: in execute_command
    ).decode('ascii')
E   UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 22: ordinal not in range(128)

During handling of the above exception, another exception occurred:
tests/test_hecate.py:34: in test_can_write_unicode
    h.await_text("☃")
../venv/lib/python3.6/site-packages/hecate/hecate.py:278: in __exit__
    self.shutdown()
../venv/lib/python3.6/site-packages/hecate/hecate.py:164: in shutdown
    self.await_exit()
../venv/lib/python3.6/site-packages/hecate/hecate.py:246: in await_exit
    self.screenshot()
../venv/lib/python3.6/site-packages/hecate/hecate.py:194: in screenshot
    result = self.tmux.capture_pane(0)
../venv/lib/python3.6/site-packages/hecate/tmux.py:124: in capture_pane
    buf = self.a_buffer()
../venv/lib/python3.6/site-packages/hecate/tmux.py:115: in a_buffer
    buffers = self.buffers()
../venv/lib/python3.6/site-packages/hecate/tmux.py:70: in buffers
    return _extract_names(self.execute_command("list-buffers"))
../venv/lib/python3.6/site-packages/hecate/tmux.py:46: in execute_command
    ).decode('ascii')
E   UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 22: ordinal not in range(128)
________________ test_uses_last_screenshot_if_server_goes_away _________________
../venv/lib/python3.6/site-packages/hecate/tmux.py:45: in execute_command
    stderr=subprocess.STDOUT
/usr/lib64/python3.6/subprocess.py:336: in check_output
    **kwargs).stdout
/usr/lib64/python3.6/subprocess.py:418: in run
    output=stdout, stderr=stderr)
E   subprocess.CalledProcessError: Command '['tmux', '-u', '-L', 'e5fa548be551afd3', 'list-buffers']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:
tests/test_hecate.py:117: in test_uses_last_screenshot_if_server_goes_away
    assert "Hello" in h.screenshot()
../venv/lib/python3.6/site-packages/hecate/hecate.py:194: in screenshot
    result = self.tmux.capture_pane(0)
../venv/lib/python3.6/site-packages/hecate/tmux.py:124: in capture_pane
    buf = self.a_buffer()
../venv/lib/python3.6/site-packages/hecate/tmux.py:115: in a_buffer
    buffers = self.buffers()
../venv/lib/python3.6/site-packages/hecate/tmux.py:70: in buffers
    return _extract_names(self.execute_command("list-buffers"))
../venv/lib/python3.6/site-packages/hecate/tmux.py:50: in execute_command
    raise CommandFailed(e.output)
E   hecate.tmux.CommandFailed: b'no server running on /tmp/tmux-1000/e5fa548be551afd3\n'
----------------------------- Captured stdout call -----------------------------
Hello
























___________________________ test_can_capture_a_pane ____________________________
tests/test_mux.py:77: in test_can_capture_a_pane
    assert len(pane_contents.split("\n")) == 50
E   AssertionError: assert 51 == 50
E    +  where 51 = len(['hello world', '', '', '', '', '', ...])
E    +    where ['hello world', '', '', '', '', '', ...] = <built-in method split of str object at 0x7fe7e4a68420>('\n')
E    +      where <built-in method split of str object at 0x7fe7e4a68420> = 'hello world\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n'.split
_______________________ test_can_detect_when_server_dies _______________________
../venv/lib/python3.6/site-packages/hecate/tmux.py:45: in execute_command
    stderr=subprocess.STDOUT
/usr/lib64/python3.6/subprocess.py:336: in check_output
    **kwargs).stdout
/usr/lib64/python3.6/subprocess.py:418: in run
    output=stdout, stderr=stderr)
E   subprocess.CalledProcessError: Command '['tmux', '-u', '-L', b'aa4087f67a5543a6', 'list-sessions']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:
tests/test_mux.py:98: in test_can_detect_when_server_dies
    mux.sessions()
../venv/lib/python3.6/site-packages/hecate/tmux.py:94: in sessions
    return _extract_names(self.execute_command("list-sessions"))
../venv/lib/python3.6/site-packages/hecate/tmux.py:50: in execute_command
    raise CommandFailed(e.output)
E   hecate.tmux.CommandFailed: b'no server running on /tmp/tmux-1000/aa4087f67a5543a6\n'
===================== 4 failed, 15 passed in 4.74 seconds ======================
```

## System info:
```bash
$ cat /proc/version 
Linux version 4.9.95-gentoo (root@Ridl3y) (gcc version 6.4.0 (Gentoo 6.4.0-r1 p1.3) ) #2 SMP Sun May 27 22:02:48 EDT 2018
```
```bash
$ tmux -V
tmux 2.6
```

Fair warning: may break tests for earlier versions of tmux, I couldn't test on those.

