### PR TITLE
Fix tmux configuration affecting the tests

### DIFF
--- a/src/hecate/tmux.py
+++ b/src/hecate/tmux.py
@@ -39,7 +39,7 @@ class Tmux(object):
 
     def execute_command(self, *command):
         try:
-            cmd = [TMUX, "-u", "-L", self.name] + list(map(str, command))
+            cmd = [TMUX, "-u", "-f", os.devnull, "-L", self.name] + list(map(str, command))
             return subprocess.check_output(
                 cmd,
                 stderr=subprocess.STDOUT


### PR DESCRIPTION
.tmux.conf that contains `pane-base-index 1` or `base-index 1` affects the testcases written with hecate that expect content to appear on pane 0. Possible that other options affect them as well.